### PR TITLE
Changed response status from 201 Created to 200 OK

### DIFF
--- a/packages/residence-verification-direct/src/routers/residenceVerificationRouter.ts
+++ b/packages/residence-verification-direct/src/routers/residenceVerificationRouter.ts
@@ -46,7 +46,7 @@ const residenceVerificationRouter = (
           "OK"
         );
         logger.info(`[END] residenceVerificationRouter`);
-        return res.status(201).json(data).end();
+        return res.status(200).json(data).end();
       } catch (error) {
         const errorRes = makeApiProblem(error, createEserviceDataPreparation);
         const correlationId = req.headers["x-correlation-id"] as string;
@@ -83,8 +83,8 @@ const residenceVerificationRouter = (
           "RESIDENCE_VERIFICATION_002",
           "OK"
         );
-        logger.info(`[END] Verfy ResidenceVerificationRouter`);
-        return res.status(201).json(data).end();
+        logger.info(`[END] Verify ResidenceVerificationRouter`);
+        return res.status(200).json(data).end();
       } catch (error) {
         const errorRes = makeApiProblem(error, createEserviceDataPreparation);
         const correlationId = req.headers["x-correlation-id"] as string;

--- a/packages/residence-verification/src/routers/residenceVerificationRouter.ts
+++ b/packages/residence-verification/src/routers/residenceVerificationRouter.ts
@@ -46,7 +46,7 @@ const residenceVerificationRouter = (
           "OK"
         );
         logger.info(`[END] residenceVerificationRouter`);
-        return res.status(201).json(data).end();
+        return res.status(200).json(data).end();
       } catch (error) {
         const errorRes = makeApiProblem(error, createEserviceDataPreparation);
         const correlationId = req.headers["x-correlation-id"] as string;
@@ -83,8 +83,8 @@ const residenceVerificationRouter = (
           "RESIDENCE_VERIFICATION_002",
           "OK"
         );
-        logger.info(`[END] Verfy ResidenceVerificationRouter`);
-        return res.status(201).json(data).end();
+        logger.info(`[END] Verify ResidenceVerificationRouter`);
+        return res.status(200).json(data).end();
       } catch (error) {
         const errorRes = makeApiProblem(error, createEserviceDataPreparation);
         const correlationId = req.headers["x-correlation-id"] as string;


### PR DESCRIPTION
Changed response status from 201 Created to 200 OK for the residence verification and direct packages' find and check API calls, as these endpoints retrieve existing data rather than creating a new resource.