### PR TITLE
PIN-8631 Add payload logging in controller

### DIFF
--- a/packages/signal-job/src/repositories/SignalHubClient.ts
+++ b/packages/signal-job/src/repositories/SignalHubClient.ts
@@ -1,5 +1,5 @@
 import axios from "axios";
-import { getPDNDTokenM2M } from "pdnd-common";
+import { getPDNDTokenM2M, logger } from "pdnd-common";
 import { shConfig } from "../config/config.js";
 
 const config = shConfig();
@@ -25,6 +25,10 @@ export const SignalHubClient = {
       objectType: "-",
       objectId: "-",
     };
+
+    logger.info(
+      `[SignalHubClient] Sending payload: ${JSON.stringify(payload)}`
+    );
 
     await axios.post(url, payload, {
       headers: {


### PR DESCRIPTION
This pull request introduces improved logging for the **signal-job** controller by adding a new log entry that prints the payload before it is sent to **SignalHub**.