### PR TITLE
Pin 8633 control over send signal hub function

### DIFF
--- a/packages/commons/src/services/signalHub/shService.ts
+++ b/packages/commons/src/services/signalHub/shService.ts
@@ -76,6 +76,6 @@ export const SHService = {
 
   async getNextSignalId(eserviceId: string): Promise<number> {
     logger.info(`[SHService] Requesting signalId increment for ${eserviceId}`);
-    return SHRepository.ensureAndIncrementSignalId(eserviceId);
+    return SHRepository.ensureAndIncrementSignalId(eserviceId); // split functionality
   },
 };

--- a/packages/commons/src/services/signalHub/shService.ts
+++ b/packages/commons/src/services/signalHub/shService.ts
@@ -49,6 +49,7 @@ export const SHService = {
         const errorMessage = (error as Error).message || String(error);
         logger.error(`[ANPRService] Connection Error: ${errorMessage}`);
       }
+      throw error;
     }
   },
 

--- a/packages/commons/test/signalHub/shService.test.ts
+++ b/packages/commons/test/signalHub/shService.test.ts
@@ -110,10 +110,13 @@ describe("SHService", () => {
         response: { status: 404 },
         message: "Not Found",
       };
+
       mockAxiosPost.mockRejectedValue(axiosError);
       mockIsAxiosError.mockReturnValue(true);
 
-      await SHService.sendSignal(mockPayload, mockToken);
+      await expect(
+        SHService.sendSignal(mockPayload, mockToken)
+      ).rejects.toEqual(axiosError);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         `[ANPRService] API Error: 404 - Not Found`
@@ -122,10 +125,13 @@ describe("SHService", () => {
 
     it("should handle generic errors correctly", async () => {
       const genericError = new Error("Connection failed");
+
       mockAxiosPost.mockRejectedValue(genericError);
       mockIsAxiosError.mockReturnValue(false);
 
-      await SHService.sendSignal(mockPayload, mockToken);
+      await expect(
+        SHService.sendSignal(mockPayload, mockToken)
+      ).rejects.toThrow("Connection failed");
 
       expect(mockLogger.error).toHaveBeenCalledWith(
         `[ANPRService] Connection Error: Connection failed`

--- a/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
+++ b/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
@@ -143,7 +143,7 @@ const residenceSubissionController = (
         logger.info(`[signalObject]: ${JSON.stringify(signalObject)}`);
 
         try {
-          await SHService.sendSignal(signalObject, m2mToken);
+          await SHService.sendSignal(signalObject, "m2mToken");
           void TrialService.insert(
             req.url,
             req.method,
@@ -154,7 +154,7 @@ const residenceSubissionController = (
           logger.error(
             `[Controller] Error sending signal. Reverting signalId for ${eserviceId}. Error: ${error}`
           );
-          throw error;
+          throw new Error(`Signal Hub Deposit Failed: ${error}`);
         }
         logger.info(`[END] residenceSubissionController update`);
         return res.status(200).json(data).end();
@@ -249,7 +249,7 @@ const residenceSubissionController = (
           logger.error(
             `[Controller] Error sending signal. Reverting signalId for ${eserviceId}. Error: ${error}`
           );
-          throw error;
+          throw new Error(`Signal Hub Deposit Failed: ${error}`);
         }
         logger.info(`[END] residenceSubissionController delete`);
         return res.status(204).end();

--- a/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
+++ b/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
@@ -142,13 +142,23 @@ const residenceSubissionController = (
         };
         logger.info(`[signalObject]: ${JSON.stringify(signalObject)}`);
 
-        await SHService.sendSignal(signalObject, m2mToken);
-        void TrialService.insert(
-          req.url,
-          req.method,
-          "RESIDENCE_SUBMISSION_001",
-          "OK"
-        );
+        try {
+          await SHService.sendSignal(signalObject, m2mToken);
+          void TrialService.insert(
+            req.url,
+            req.method,
+            "RESIDENCE_SUBMISSION_001",
+            "OK"
+          );
+        } catch (error) {
+          logger.error(
+            `[Controller] Error sending signal. Reverting signalId for ${eserviceId}. Error: ${error}`
+          );
+          await SHService.rollbackSignalId(eserviceId);
+
+          // Rethrow the error to be caught by the outer catch
+          throw error;
+        }
         logger.info(`[END] residenceSubissionController update`);
         return res.status(200).json(data).end();
       } catch (error) {
@@ -230,14 +240,20 @@ const residenceSubissionController = (
           signalId,
           signalType: "DELETE",
         };
-        await SHService.sendSignal(signalObject, m2mToken);
-
-        void TrialService.insert(
-          req.url,
-          req.method,
-          "RESIDENCE_SUBMISSION_001",
-          "OK"
-        );
+        try {
+          await SHService.sendSignal(signalObject, m2mToken);
+          void TrialService.insert(
+            req.url,
+            req.method,
+            "RESIDENCE_SUBMISSION_001",
+            "OK"
+          );
+        } catch (error) {
+          logger.error(
+            `[Controller] Error sending signal. Reverting signalId for ${eserviceId}. Error: ${error}`
+          );
+          throw error;
+        }
         logger.info(`[END] residenceSubissionController delete`);
         return res.status(204).end();
       } catch (error) {

--- a/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
+++ b/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
@@ -143,7 +143,7 @@ const residenceSubissionController = (
         logger.info(`[signalObject]: ${JSON.stringify(signalObject)}`);
 
         try {
-          await SHService.sendSignal(signalObject, "m2mToken");
+          await SHService.sendSignal(signalObject, m2mToken);
           void TrialService.insert(
             req.url,
             req.method,

--- a/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
+++ b/packages/residence-submission/src/routers/residenceSubmissionRouter.ts
@@ -154,9 +154,6 @@ const residenceSubissionController = (
           logger.error(
             `[Controller] Error sending signal. Reverting signalId for ${eserviceId}. Error: ${error}`
           );
-          await SHService.rollbackSignalId(eserviceId);
-
-          // Rethrow the error to be caught by the outer catch
           throw error;
         }
         logger.info(`[END] residenceSubissionController update`);


### PR DESCRIPTION
This Pull Request modifies error handling in the Residence Submission router to ensure any errors in communication with Signal Hub. Returning an error state to the client, meeting integration requirements that include handling signal resending in the event of a malfunction.  