### PR TITLE
Pin 8735 Residence verification response contains non-compliant body

### DIFF
--- a/packages/commons/src/services/reisdence-submission/residenceSubmissionService.ts
+++ b/packages/commons/src/services/reisdence-submission/residenceSubmissionService.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { z } from "zod";
 import { RequestAR003 } from "../../zod/residence-submission/requestAR003.js";
 import { Subject } from "../../db/schema/residence-verification/subject.model.js";
@@ -95,9 +96,18 @@ export const ResidenceSubmissionService = {
             `[DEBUG UPDATE] Found existing addresses for ${id}. Updating using ID (CF).`
           );
 
+          const today = new Date().toISOString().split("T")[0];
+
+          const addressToUpdate = {
+            ...updatedAddress,
+            address_start_date: today,
+          };
+
+          logger.info(`[DEBUG UPDATE] Setting new address date to: ${today}`);
+
           await DataPreparationRepository.updateAddressById(
             id,
-            updatedAddress as unknown as Address
+            addressToUpdate as unknown as Address
           );
         } else {
           logger.warn(
@@ -187,9 +197,15 @@ export const ResidenceSubmissionService = {
       await DataPreparationRepository.createSubject(newSubject);
 
       if (newAddress) {
+        const today = new Date().toISOString().split("T")[0];
+
+        const addressToSave = {
+          ...newAddress,
+          address_start_date: today,
+        };
         logger.info(`[DEBUG CREATE] Calling Repo createAddress...`);
         await DataPreparationRepository.createAddress(
-          newAddress as unknown as Address
+          addressToSave as unknown as Address
         );
       } else {
         logger.warn(

--- a/packages/commons/test/residence-submission/residence-submission.test.ts
+++ b/packages/commons/test/residence-submission/residence-submission.test.ts
@@ -93,7 +93,7 @@ export const mockAddress = {
   id: "123e4667-e89b-12d3-a456-426614174000",
   address_type: "residence",
   note_address: "Indirizzo principale del soggetto",
-  address_start_date: "2020-01-15",
+  address_start_date: "2025-12-10",
   address_municipality_name: "Roma",
   address_municipality_istat_code: "H501",
   toponym_denomination: "Via del Corso",

--- a/packages/residence-verification/src/controllers/residenceVerificationController.ts
+++ b/packages/residence-verification/src/controllers/residenceVerificationController.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { UserModel } from "pdnd-models";
 import { logger, getContext, userService, translateKeys } from "pdnd-common";
 import { userModelNotFound } from "../exceptions/errors.js";
@@ -48,6 +49,15 @@ class ResidenceVerificationController {
       idOperazioneANPR: internalRequest.operationId,
       listaSoggetti: {
         datiSoggetto: data.map((user) => {
+          const rawDate =
+            user.address?.addressStartDate ||
+            (user as any).address_start_date ||
+            (user.address as any)?.address_start_date;
+
+          const dataInserimentoResidenza = rawDate
+            ? new Date(rawDate).toISOString().split("T")[0]
+            : new Date().toISOString().split("T")[0];
+
           const flatItalianObj: RispostaAR002OK = translateKeys(
             user,
             RES_ENG_TO_ITA_KEYS,
@@ -55,13 +65,16 @@ class ResidenceVerificationController {
           );
 
           const infoSoggettoEnte = Object.entries(flatItalianObj).map(
-            ([chiave, valore]) => {
+            ([chiave, valore], index) => {
               const isDate = chiave.toUpperCase().includes("DATA");
+
               return {
+                id: String(index + 1),
                 chiave,
                 valore: (isDate ? "D" : "A") as "A" | "N" | "S" | "D",
-                valoreTesto: !isDate ? String(valore) : undefined,
-                valoreData: isDate ? String(valore) : undefined,
+                valoreTesto: String(valore || ""),
+                valoreData: dataInserimentoResidenza,
+                dettaglio: "",
               };
             }
           );

--- a/packages/residence-verification/src/model/generated/api.ts
+++ b/packages/residence-verification/src/model/generated/api.ts
@@ -36,16 +36,70 @@ const TipoDatiNascitaE000 = z
   })
   .partial()
   .passthrough();
-const TipocriteriaAR002 = z
+const TipoParametriRicercaAR001 = z
   .object({
     subjectId: z.string(),
     id: z.string(),
     surname: z.string(),
-    nosurname: z.string(),
+    noSurname: z.string(),
     name: z.string(),
-    noname: z.string(),
+    noName: z.string(),
     gender: z.string(),
     birthDate: TipoDatiNascitaE000,
+  })
+  .partial()
+  .passthrough();
+const TipoRichiestaAR001 = z
+  .object({
+    dateOfRequest: z.string(),
+    motivation: z.string(),
+    useCase: z.string(),
+  })
+  .passthrough();
+const RichiestaAR001 = z
+  .object({
+    operationId: z.string(),
+    criteria: TipoParametriRicercaAR001,
+    requestData: TipoRichiestaAR001,
+  })
+  .passthrough();
+const TipoCodiceFiscale = z
+  .object({
+    subjectId: z.string(),
+    subjectIdValidity: z.string(),
+    dataAttributionValidity: z.string(),
+  })
+  .partial()
+  .passthrough();
+const TipoLuogoEvento = z
+  .object({
+    exceptionalPlace: z.string(),
+    municipality: TipoComune,
+    place: TipoLocalita,
+  })
+  .partial()
+  .passthrough();
+const TipoIdSchedaSoggettoComune = z
+  .object({ idCommonSubjectDataIstat: z.string(), idSubjectData: z.string() })
+  .partial()
+  .passthrough();
+const TipoGeneralita = z
+  .object({
+    subjectId: TipoCodiceFiscale,
+    surname: z.string(),
+    noSurname: z.string(),
+    name: z.string(),
+    noName: z.string(),
+    gender: z.string(),
+    birthDate: z.string(),
+    noDay: z.string(),
+    noMonth: z.string(),
+    birthPlace: TipoLuogoEvento,
+    AIRESubject: z.string(),
+    yearExpatriation: z.string(),
+    idCommonSubjectData: TipoIdSchedaSoggettoComune,
+    idSubjectData: z.string(),
+    note: z.string(),
   })
   .partial()
   .passthrough();
@@ -385,17 +439,6 @@ const AnomaliaAR002 = z
   })
   .partial()
   .passthrough();
-const TipoErroriAnomalia = z
-  .object({
-    warningErrorCode: z.string(),
-    warningErrorType: z.string(),
-    warningErrorText: z.string(),
-    warningErrorObject: z.string(),
-    warningErrorField: z.string(),
-    warningErrorValue: z.string(),
-  })
-  .partial()
-  .passthrough();
 const RispostaAR002OK = z
   .object({
     idOperazioneANPR: z.string(),
@@ -429,7 +472,13 @@ export const schemas = {
   TipoLocalita,
   TipoLuogoNascitaE000,
   TipoDatiNascitaE000,
-  TipocriteriaAR002,
+  TipoParametriRicercaAR001,
+  TipoRichiestaAR001,
+  RichiestaAR001,
+  TipoCodiceFiscale,
+  TipoLuogoEvento,
+  TipoIdSchedaSoggettoComune,
+  TipoGeneralita,
   TipoToponimo,
   TipoCivicoInterno,
   TipoNumeroCivico,
@@ -471,6 +520,43 @@ export const schemas = {
 };
 
 const endpoints = makeApi([
+  {
+    method: "post",
+    path: "/residence-verification",
+    alias: "AR001",
+    description: `Search for a residential address`,
+    requestFormat: "json",
+    parameters: [
+      {
+        name: "body",
+        type: "Body",
+        schema: RichiestaAR001,
+      },
+    ],
+    response: RispostaAR001,
+    errors: [
+      {
+        status: 400,
+        description: `Bad request`,
+        schema: z.void(),
+      },
+      {
+        status: 401,
+        description: `Unauthorized`,
+        schema: z.void(),
+      },
+      {
+        status: 403,
+        description: `Forbidden`,
+        schema: z.void(),
+      },
+      {
+        status: 429,
+        description: `Too Many Requests`,
+        schema: z.void(),
+      },
+    ],
+  },
   {
     method: "post",
     path: "/residence-verification/check",


### PR DESCRIPTION

This pull request addresses missing data persistence for the residence start date and fixes the AR002 verification API response to ensure the returned body is structurally complete and consistent. In the ResidenceSubmissionService, we implemented logic to auto-generate the address_start_date during both creation and update operations to ensure this field is correctly saved in the database. Consequently, we refactored the ResidenceVerificationController mapping to fix previous incomplete JSON outputs: the response now returns a full object structure for every field, where valoreTesto is always populated (containing the actual content, even for date fields) and valoreData consistently reflects the record's validity date, preventing missing properties in the final response.